### PR TITLE
isAlive() -> is_alive()

### DIFF
--- a/tests/test_python_dynamodb_lock.py
+++ b/tests/test_python_dynamodb_lock.py
@@ -54,16 +54,16 @@ class TestDynamoDBLockClient(unittest.TestCase):
         heartbeat_sender = self.lock_client._heartbeat_sender_thread
         self.assertIsNotNone(heartbeat_sender)
         self.assertTrue(heartbeat_sender.isDaemon())
-        self.assertTrue(heartbeat_sender.isAlive())
+        self.assertTrue(heartbeat_sender.is_alive())
         heartbeat_checker = self.lock_client._heartbeat_checker_thread
         self.assertIsNotNone(heartbeat_checker)
         self.assertTrue(heartbeat_checker.isDaemon())
-        self.assertTrue(heartbeat_checker.isAlive())
+        self.assertTrue(heartbeat_checker.is_alive())
         # now, close the client
         self.lock_client.close()
         # and check that the threads are also shutdown
-        self.assertFalse(heartbeat_sender.isAlive())
-        self.assertFalse(heartbeat_checker.isAlive())
+        self.assertFalse(heartbeat_sender.is_alive())
+        self.assertFalse(heartbeat_checker.is_alive())
 
 
     def test_send_heartbeat_success(self):


### PR DESCRIPTION
The `isAlive` method was deprecated in python3.7 and finally removed in python3.9.

Fixes the following error in the test suite when run with python3.9
```
python3.9-python-dynamodb-lock> ============================= test session starts ==============================
python3.9-python-dynamodb-lock> platform linux -- Python 3.9.2, pytest-6.2.2, py-1.9.0, pluggy-0.13.1
python3.9-python-dynamodb-lock> rootdir: /build/source
python3.9-python-dynamodb-lock> collected 27 items                                                             
python3.9-python-dynamodb-lock> tests/test_python_dynamodb_lock.py ......F....................           [100%]
python3.9-python-dynamodb-lock> =================================== FAILURES ===================================
python3.9-python-dynamodb-lock> ________________ TestDynamoDBLockClient.test_background_threads ________________
python3.9-python-dynamodb-lock> self = <tests.test_python_dynamodb_lock.TestDynamoDBLockClient testMethod=test_background_threads>
python3.9-python-dynamodb-lock> def test_background_threads(self):
python3.9-python-dynamodb-lock> heartbeat_sender = self.lock_client._heartbeat_sender_thread
python3.9-python-dynamodb-lock> self.assertIsNotNone(heartbeat_sender)
python3.9-python-dynamodb-lock> self.assertTrue(heartbeat_sender.isDaemon())
python3.9-python-dynamodb-lock> >       self.assertTrue(heartbeat_sender.isAlive())
python3.9-python-dynamodb-lock> E       AttributeError: 'Thread' object has no attribute 'isAlive'
python3.9-python-dynamodb-lock> tests/test_python_dynamodb_lock.py:57: AttributeError
python3.9-python-dynamodb-lock> =========================== short test summary info ============================
python3.9-python-dynamodb-lock> FAILED tests/test_python_dynamodb_lock.py::TestDynamoDBLockClient::test_background_threads
python3.9-python-dynamodb-lock> ========================= 1 failed, 26 passed in 5.45s =========================
```